### PR TITLE
Updated c2d to point to R81 image in GCP

### DIFF
--- a/gcp/deployment-packages/autoscale-byol/c2d_deployment_configuration.json
+++ b/gcp/deployment-packages/autoscale-byol/c2d_deployment_configuration.json
@@ -1,6 +1,6 @@
 {
   "defaultDeploymentType": "MULTI_VM",
-  "imageName": "check-point-r8040-gw-byol-mig-294-904-v20210715",
+  "imageName": "check-point-r81-gw-byol-mig-392-915-v20210811",
   "projectId": "checkpoint-public",
   "templateName": "nonexistent_template",
   "useSolutionPackage": "true"

--- a/gcp/deployment-packages/autoscale-payg/c2d_deployment_configuration.json
+++ b/gcp/deployment-packages/autoscale-payg/c2d_deployment_configuration.json
@@ -1,6 +1,6 @@
 {
   "defaultDeploymentType": "MULTI_VM",
-  "imageName": "check-point-r8040-gw-payg-mig-294-904-v20210715",
+  "imageName": "check-point-r81-gw-payg-mig-392-915-v20210811",
   "projectId": "checkpoint-public",
   "templateName": "nonexistent_template",
   "useSolutionPackage": "true"

--- a/gcp/deployment-packages/ha-byol/c2d_deployment_configuration.json
+++ b/gcp/deployment-packages/ha-byol/c2d_deployment_configuration.json
@@ -1,6 +1,6 @@
 {
   "defaultDeploymentType": "MULTI_VM",
-  "imageName": "check-point-r8040-gw-byol-cluster-294-904-v20210715",
+  "imageName": "check-point-r81-gw-byol-cluster-392-915-v20210811",
   "projectId": "checkpoint-public",
   "templateName": "nonexistent_template",
   "useSolutionPackage": "true"

--- a/gcp/deployment-packages/ha-payg/c2d_deployment_configuration.json
+++ b/gcp/deployment-packages/ha-payg/c2d_deployment_configuration.json
@@ -1,6 +1,6 @@
 {
   "defaultDeploymentType": "MULTI_VM",
-  "imageName": "check-point-r8040-gw-payg-cluster-294-904-v20210715",
+  "imageName": "check-point-r81-gw-payg-cluster-392-915-v20210811",
   "projectId": "checkpoint-public",
   "templateName": "nonexistent_template",
   "useSolutionPackage": "true"

--- a/gcp/deployment-packages/single-byol/c2d_deployment_configuration.json
+++ b/gcp/deployment-packages/single-byol/c2d_deployment_configuration.json
@@ -1,6 +1,6 @@
 {
   "defaultDeploymentType": "SINGLE_VM",
-  "imageName": "check-point-r8040-gw-byol-single-294-904-v20210715",
+  "imageName": "check-point-r81-gw-byol-single-392-915-v20210811",
   "projectId": "checkpoint-public",
   "templateName": "nonexistent_template",
   "useSolutionPackage": "true"

--- a/gcp/deployment-packages/single-payg/c2d_deployment_configuration.json
+++ b/gcp/deployment-packages/single-payg/c2d_deployment_configuration.json
@@ -1,6 +1,6 @@
 {
   "defaultDeploymentType": "SINGLE_VM",
-  "imageName": "check-point-r8040-gw-payg-single-294-904-v20210715",
+  "imageName": "check-point-r81-gw-byol-single-392-915-v20210811",
   "projectId": "checkpoint-public",
   "templateName": "nonexistent_template",
   "useSolutionPackage": "true"

--- a/gcp/deployment-packages/single-payg/c2d_deployment_configuration.json
+++ b/gcp/deployment-packages/single-payg/c2d_deployment_configuration.json
@@ -1,6 +1,6 @@
 {
   "defaultDeploymentType": "SINGLE_VM",
-  "imageName": "check-point-r81-gw-byol-single-392-915-v20210811",
+  "imageName": "check-point-r81-gw-payg-single-392-915-v20210811",
   "projectId": "checkpoint-public",
   "templateName": "nonexistent_template",
   "useSolutionPackage": "true"


### PR DESCRIPTION
Changed default version of c2d files in all GCP templates to R81.