### PR TITLE
AWS | CFT & TF | Add support for Elastic Load Balancer Health Checks

### DIFF
--- a/aws/templates/asg/autoscale.yaml
+++ b/aws/templates/asg/autoscale.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Create an Auto Scaling group of Check Point gateways (20240204)
+Description: Create an Auto Scaling group of Check Point gateways (20240417)
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -479,6 +479,8 @@ Resources:
       MaxSize: !Ref GatewaysMaxSize
       LoadBalancerNames: !If [CreateELB, [!Ref ElasticLoadBalancer], !Ref 'AWS::NoValue']
       TargetGroupARNs: !If [ProvidedTargetGroups, !Split [',', !Ref GatewaysTargetGroups], !Ref 'AWS::NoValue']
+      HealthCheckGracePeriod: 3600
+      HealthCheckType: ELB
       NotificationConfiguration: !If
         - ProvidedAdminEmail
         - TopicARN: !Ref NotificationTopic

--- a/aws/templates/management/management.yaml
+++ b/aws/templates/management/management.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Deploys a Check Point Management Server (20240204)
+Description: Deploys a Check Point Management Server (20240417)
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -446,6 +446,10 @@ Resources:
           IpProtocol: tcp
           FromPort: 18192
           ToPort: 18192
+        - CidrIp: !Ref GatewaysAddresses
+          IpProtocol: tcp
+          FromPort: 18208
+          ToPort: 18208
         - CidrIp: !Ref GatewaysAddresses
           IpProtocol: tcp
           FromPort: 18210

--- a/aws/templates/mds/mds.yaml
+++ b/aws/templates/mds/mds.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Deploys a Check Point Multi-Domain Server (20240204)
+Description: Deploys a Check Point Multi-Domain Server (20240417)
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -414,6 +414,10 @@ Resources:
           IpProtocol: tcp
           FromPort: 18192
           ToPort: 18192
+        - CidrIp: !Ref GatewaysAddresses
+          IpProtocol: tcp
+          FromPort: 18208
+          ToPort: 18208
         - CidrIp: !Ref GatewaysAddresses
           IpProtocol: tcp
           FromPort: 18210

--- a/terraform/aws/autoscale-gwlb/README.md
+++ b/terraform/aws/autoscale-gwlb/README.md
@@ -164,18 +164,19 @@ secret_key = "my-secret-key"
 ## Revision History
 In order to check the template version, please refer to [sk116585](https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk116585)
 
-| Template Version | Description                                                                                                   |
-|------------------|---------------------------------------------------------------------------------------------------------------|
-| 20220414         | First release of Check Point Auto Scaling GWLB Terraform module for AWS                                       |
-| 20220606         | New instance type support                                                                                     |
-| 20221123         | R81.20 version support                                                                                        |
-| 20221226         | Support ASG Launch Template instead of Launch Configuration                                                   |
-| 20230521         | - Change default shell for the admin user to /etc/cli.sh<br/>- Add description for reserved words in hostname |
-| 20230806         | Add support for c6in instance type                                                                            |
-| 20230829         | Change default Check Point version to R81.20                                                                  |
-| 20230914         | Add support for maintenance mode password                                                                     |
-| 20230923         | Add support for C5d instance type                                                                             |
-| 20231012         | Update AWS Terraform provider version to 5.20.1                                                               |
+| Template Version | Description                                                                                                                                                      |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 20220414         | First release of Check Point Auto Scaling GWLB Terraform module for AWS                                                                                          |
+| 20220606         | New instance type support                                                                                                                                        |
+| 20221123         | R81.20 version support                                                                                                                                           |
+| 20221226         | Support ASG Launch Template instead of Launch Configuration                                                                                                      |
+| 20230521         | - Change default shell for the admin user to /etc/cli.sh<br/>- Add description for reserved words in hostname                                                    |
+| 20230806         | Add support for c6in instance type                                                                                                                               |
+| 20230829         | Change default Check Point version to R81.20                                                                                                                     |
+| 20230914         | Add support for maintenance mode password                                                                                                                        |
+| 20230923         | Add support for C5d instance type                                                                                                                                |
+| 20231012         | Update AWS Terraform provider version to 5.20.1                                                                                                                  |
+| 20240414         | - Add support for Elastic Load Balancer Health Checks.<br/>- EC2 Auto Scaling will start to detect and act on health checks performed by Elastic Load Balancing. |
 
 ## License
 

--- a/terraform/aws/autoscale-gwlb/main.tf
+++ b/terraform/aws/autoscale-gwlb/main.tf
@@ -84,7 +84,8 @@ resource "aws_autoscaling_group" "asg" {
   max_size = var.maximum_group_size
   target_group_arns = var.target_groups
   vpc_zone_identifier = var.subnet_ids
-  health_check_grace_period = 0
+  health_check_grace_period = 3600
+  health_check_type = "ELB"
 
   tag {
       key = "Name"

--- a/terraform/aws/autoscale/README.md
+++ b/terraform/aws/autoscale/README.md
@@ -176,20 +176,21 @@ secret_key = "my-secret-key"
 ## Revision History
 In order to check the template version, please refer to [sk116585](https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk116585)
 
-| Template Version | Description                                                        |
-|------------------|--------------------------------------------------------------------|
-| 20200318         | First release of Check Point Auto Scaling Terraform module for AWS |
-| 20210309         | AWS Terraform modules refactor                                     |
-| 20210329         | Stability fixes                                                    |
-| 20220606         | New instance type support                                          |
-| 20221123         | R81.20 version support                                             |
-| 20221226         | Support ASG Launch Template instead of Launch Configuration        |
-| 20230521         | Change default shell for the admin user to /etc/cli.sh             |
-| 20230806         | Add support for c6in instance type                                 | 
-| 20230829         | Change default Check Point version to R81.20                       |
-| 20230914         | Add support for maintenance mode password                          |
-| 20230923         | Add support for C5d instance type                                  |
-| 20231012         | Update AWS Terraform provider version to 5.20.1                    |
+| Template Version | Description                                                                                                                                                      |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 20200318         | First release of Check Point Auto Scaling Terraform module for AWS                                                                                               |
+| 20210309         | AWS Terraform modules refactor                                                                                                                                   |
+| 20210329         | Stability fixes                                                                                                                                                  |
+| 20220606         | New instance type support                                                                                                                                        |
+| 20221123         | R81.20 version support                                                                                                                                           |
+| 20221226         | Support ASG Launch Template instead of Launch Configuration                                                                                                      |
+| 20230521         | Change default shell for the admin user to /etc/cli.sh                                                                                                           |
+| 20230806         | Add support for c6in instance type                                                                                                                               | 
+| 20230829         | Change default Check Point version to R81.20                                                                                                                     |
+| 20230914         | Add support for maintenance mode password                                                                                                                        |
+| 20230923         | Add support for C5d instance type                                                                                                                                |
+| 20231012         | Update AWS Terraform provider version to 5.20.1                                                                                                                  |
+| 20240414         | - Add support for Elastic Load Balancer Health Checks.<br/>- EC2 Auto Scaling will start to detect and act on health checks performed by Elastic Load Balancing. |
 
 ## License
 

--- a/terraform/aws/autoscale/main.tf
+++ b/terraform/aws/autoscale/main.tf
@@ -83,7 +83,8 @@ resource "aws_autoscaling_group" "asg" {
   load_balancers = aws_elb.proxy_elb.*.name
   target_group_arns = var.target_groups
   vpc_zone_identifier = var.subnet_ids
-  health_check_grace_period = 0
+  health_check_grace_period = 3600
+  health_check_type = "ELB"
 
   tag {
       key = "Name"

--- a/terraform/aws/management/main.tf
+++ b/terraform/aws/management/main.tf
@@ -39,6 +39,12 @@ resource "aws_security_group" "management_sg" {
     cidr_blocks = [var.gateway_addresses]
   }
   ingress {
+    from_port = 18208
+    to_port = 18208
+    protocol = "tcp"
+    cidr_blocks = [var.gateway_addresses]
+  }
+  ingress {
     from_port = 18210
     to_port = 18210
     protocol = "tcp"

--- a/terraform/aws/mds/main.tf
+++ b/terraform/aws/mds/main.tf
@@ -45,6 +45,12 @@ resource "aws_security_group" "mds_sg" {
     cidr_blocks = [var.gateway_addresses]
   }
   ingress {
+    from_port = 18208
+    to_port = 18208
+    protocol = "tcp"
+    cidr_blocks = [var.gateway_addresses]
+  }
+  ingress {
     from_port = 18210
     to_port = 18210
     protocol = "tcp"


### PR DESCRIPTION
EC2 Auto Scaling will start to detect and act on health checks performed by Elastic Load Balancing