### PR TITLE
AWS QuickStart GWLB | remove R80.40

### DIFF
--- a/aws/templates/gwlb-asg/README.md
+++ b/aws/templates/gwlb-asg/README.md
@@ -48,7 +48,7 @@
             <td width="40%">
             Deploys and configures a Quick Start AWS Auto Scaling Group configured for Gateway Load Balancer in a Centralized Security VPC, and Servers in Servers VPC.<br/><br/>For more details, refer to <a href="https://sc1.checkpoint.com/documents/IaaS/WebAdminGuides/EN/CP_CloudGuard_Network_for_AWS_Gateway_Load_Balancer_ASG/Default.htm">CloudGuard Network for AWS Centralized Gateway Load Balancer R80.40 Deployment Guide</a>.
             </td>
-            <td width="40%">Deploys a Gateway Load Balancer, Check Point CloudGuard IaaS Security Gateway Auto Scaling Group, optionally a Security Management Server into an existing Security VPC, Gateway Load Balancer Endpoints (1 per Availability Zone), Application Load Balancer and Servers into an existing in Servers' VPC.</br>
+            <td width="40%">Deploys a Gateway Load Balancer, Check Point CloudGuard IaaS Security Gateway Auto Scaling Group, optionally a Security Management Server into an existing Security VPC, Gateway Load Balancer Endpoints (1 per Availability Zone), Application Load Balancer and Servers into an existing Servers' VPC.</br>
 			</td>
             <td><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://cgi-cfts.s3.amazonaws.com/gwlb/qs-gwlb.yaml"><img src="../../images/launch.png"/></a></td>
         </tr>

--- a/aws/templates/gwlb-asg/README.md
+++ b/aws/templates/gwlb-asg/README.md
@@ -48,7 +48,11 @@
             <td width="40%">
             Deploys and configures a Quick Start AWS Auto Scaling Group configured for Gateway Load Balancer in a Centralized Security VPC, and Servers in Servers VPC.<br/><br/>For more details, refer to <a href="https://sc1.checkpoint.com/documents/IaaS/WebAdminGuides/EN/CP_CloudGuard_Network_for_AWS_Gateway_Load_Balancer_ASG/Default.htm">CloudGuard Network for AWS Centralized Gateway Load Balancer R80.40 Deployment Guide</a>.
             </td>
+<<<<<<< HEAD
             <td width="40%">Deploys a Gateway Load Balancer, Check Point CloudGuard IaaS Security Gateway Auto Scaling Group, optionally a Security Management Server into an existing Security VPC, Gateway Load Balancer Endpoints (1 per Availability Zone), Application Load Balancer and Servers into an existing Servers' VPC.</br>
+=======
+            <td width="40%">Deploys a Gateway Load Balancer, Check Point CloudGuard IaaS Security Gateway Auto Scaling Group, optionally a Security Management Server into an existing Security VPC, Gateway Load Balancer Endpoints (1 per Availability Zone), Application Load Balancer and Servers into an existing in Servers' VPC.</br>
+>>>>>>> 6667c7f (remove message)
 			</td>
             <td><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://cgi-cfts.s3.amazonaws.com/gwlb/qs-gwlb.yaml"><img src="../../images/launch.png"/></a></td>
         </tr>

--- a/aws/templates/gwlb-asg/README.md
+++ b/aws/templates/gwlb-asg/README.md
@@ -48,11 +48,7 @@
             <td width="40%">
             Deploys and configures a Quick Start AWS Auto Scaling Group configured for Gateway Load Balancer in a Centralized Security VPC, and Servers in Servers VPC.<br/><br/>For more details, refer to <a href="https://sc1.checkpoint.com/documents/IaaS/WebAdminGuides/EN/CP_CloudGuard_Network_for_AWS_Gateway_Load_Balancer_ASG/Default.htm">CloudGuard Network for AWS Centralized Gateway Load Balancer R80.40 Deployment Guide</a>.
             </td>
-<<<<<<< HEAD
-            <td width="40%">Deploys a Gateway Load Balancer, Check Point CloudGuard IaaS Security Gateway Auto Scaling Group, optionally a Security Management Server into an existing Security VPC, Gateway Load Balancer Endpoints (1 per Availability Zone), Application Load Balancer and Servers into an existing Servers' VPC.</br>
-=======
             <td width="40%">Deploys a Gateway Load Balancer, Check Point CloudGuard IaaS Security Gateway Auto Scaling Group, optionally a Security Management Server into an existing Security VPC, Gateway Load Balancer Endpoints (1 per Availability Zone), Application Load Balancer and Servers into an existing in Servers' VPC.</br>
->>>>>>> 6667c7f (remove message)
 			</td>
             <td><a href="https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://cgi-cfts.s3.amazonaws.com/gwlb/qs-gwlb.yaml"><img src="../../images/launch.png"/></a></td>
         </tr>

--- a/aws/templates/gwlb-asg/qs-gwlb-master.yaml
+++ b/aws/templates/gwlb-asg/qs-gwlb-master.yaml
@@ -529,9 +529,6 @@ Parameters:
     Type: String
     Default: R81.20-BYOL
     AllowedValues:
-      - R80.40-BYOL
-      - R80.40-PAYG-NGTP
-      - R80.40-PAYG-NGTX
       - R81.20-BYOL
       - R81.20-PAYG-NGTP
       - R81.20-PAYG-NGTX
@@ -700,8 +697,6 @@ Parameters:
     Type: String
     Default: R81.20-BYOL
     AllowedValues:
-      - R80.40-BYOL
-      - R80.40-PAYG
       - R81-BYOL
       - R81-PAYG
       - R81.10-BYOL

--- a/aws/templates/gwlb-asg/qs-gwlb.yaml
+++ b/aws/templates/gwlb-asg/qs-gwlb.yaml
@@ -434,9 +434,6 @@ Parameters:
     Type: String
     Default: R81.20-BYOL
     AllowedValues:
-      - R80.40-BYOL
-      - R80.40-PAYG-NGTP
-      - R80.40-PAYG-NGTX
       - R81.20-BYOL
       - R81.20-PAYG-NGTP
       - R81.20-PAYG-NGTX
@@ -605,8 +602,6 @@ Parameters:
     Type: String
     Default: R81.20-BYOL
     AllowedValues:
-      - R80.40-BYOL
-      - R80.40-PAYG
       - R81-BYOL
       - R81-PAYG
       - R81.10-BYOL


### PR DESCRIPTION
AWS QuickStart GWLB CFT,
Remove R8040 version from Gateways and management 