### PR TITLE
AWS MDS change the default instance type to m5.2xlarge

### DIFF
--- a/aws/templates/mds/mds.yaml
+++ b/aws/templates/mds/mds.yaml
@@ -115,7 +115,7 @@ Parameters:
   MDSInstanceType:
     Description: The instance type of the Multi-Domain Server.
     Type: String
-    Default: m5.12xlarge
+    Default: m5.2xlarge
     AllowedValues:
       - c5.large
       - c5.xlarge

--- a/terraform/aws/mds/variables.tf
+++ b/terraform/aws/mds/variables.tf
@@ -35,7 +35,7 @@ variable "mds_name" {
 variable "mds_instance_type" {
   type = string
   description = "The instance type of the Multi-Domain Server"
-  default = "m5.12xlarge"
+  default = "m5.2xlarge"
 }
 module "validate_instance_type" {
   source = "../modules/common/instance_type"


### PR DESCRIPTION
AWS MDS change the default instance type to m5.2xlarge 