### PR TITLE
Corrective Action: disk_type_allowed_values

### DIFF
--- a/terraform/gcp/single-into-existing-vpc/locals.tf
+++ b/terraform/gcp/single-into-existing-vpc/locals.tf
@@ -33,9 +33,9 @@ locals {
   // Will fail if var.admin_shell is invalid
   validate_admin_shell = index(local.admin_shell_allowed_values, var.admin_shell)
   disk_type_allowed_values = [
-    "SSD Persistent Disk",
-    "Balanced Persistent Disk",
-    "Standard Persistent Disk"]
+    "pd-ssd",
+    "pd-balanced",
+    "pd-standard"]
   // Will fail if var.disk_type is invalid
   validate_disk_type = index(local.disk_type_allowed_values, var.diskType)
   adminPasswordSourceMetadata = var.generatePassword ?random_string.generated_password.result : ""


### PR DESCRIPTION
Making a change to the allowed list of disk_type_allowed_values variable in **locals.tf**

This is in alignment with [Open Issue](https://github.com/CheckPointSW/CloudGuardIaaS/issues/399). 

This applies specifically to the terraform for deployment to GCP in an existing VPC.