### PR TITLE
VSECPC-6916 | Terraform | Added length limit to prefix and asg-name

### DIFF
--- a/terraform/aws/autoscale-gwlb/variables.tf
+++ b/terraform/aws/autoscale-gwlb/variables.tf
@@ -22,11 +22,19 @@ variable "prefix" {
   type = string
   description = "(Optional) Instances name prefix"
   default = ""
+    validation {
+    condition     = length(var.prefix) <= 40
+    error_message = "Prefix can not exceed 40 characters."
+  }
 }
 variable "asg_name" {
   type = string
   description = "Autoscaling Group name"
-  default = "Check-Point-ASG-tf"
+  default = "Check-Point-Security-Gateway-AutoScaling-Group-tf"
+  validation {
+    condition     = length(var.asg_name) <= 100
+    error_message = "Autoscaling Group name can not exceed 100 characters."
+  }
 }
 
 // --- VPC Network Configuration ---

--- a/terraform/aws/autoscale/variables.tf
+++ b/terraform/aws/autoscale/variables.tf
@@ -22,11 +22,19 @@ variable "prefix" {
   type = string
   description = "(Optional) Instances name prefix"
   default = ""
+    validation {
+    condition     = length(var.prefix) <= 40
+    error_message = "Prefix can not exceed 40 characters."
+  }
 }
 variable "asg_name" {
   type = string
   description = "Autoscaling Group name"
-  default = "Check-Point-ASG-tf"
+  default = "Check-Point-Security-Gateway-AutoScaling-Group-tf"
+  validation {
+    condition     = length(var.asg_name) <= 100
+    error_message = "Autoscaling Group name can not exceed 100 characters."
+  }
 }
 
 // --- VPC Network Configuration ---

--- a/terraform/aws/modules/custom-autoscale/variables.tf
+++ b/terraform/aws/modules/custom-autoscale/variables.tf
@@ -5,11 +5,19 @@ variable "prefix" {
   type = string
   description = "(Optional) Instances name prefix"
   default = ""
+    validation {
+    condition     = length(var.prefix) <= 40
+    error_message = "Prefix can not exceed 40 characters."
+  }
 }
 variable "asg_name" {
   type = string
   description = "Autoscaling Group name"
-  default = "Check-Point-ASG-tf"
+  default = "Check-Point-Security-Gateway-AutoScaling-Group-tf"
+  validation {
+    condition     = length(var.asg_name) <= 100
+    error_message = "Autoscaling Group name can not exceed 100 characters."
+  }
 }
 
 // --- VPC Network Configuration ---

--- a/terraform/aws/qs-autoscale-master/variables.tf
+++ b/terraform/aws/qs-autoscale-master/variables.tf
@@ -23,11 +23,19 @@ variable "prefix" {
   type = string
   description = "(Optional) Instances name prefix"
   default = ""
+  validation {
+    condition     = length(var.prefix) <= 40
+    error_message = "Prefix can not exceed 40 characters."
+  }
 }
 variable "asg_name" {
   type = string
   description = "Autoscaling Group name"
-  default = "Check-Point-ASG-tf"
+  default = "Check-Point-Security-Gateway-AutoScaling-Group-tf"
+  validation {
+    condition     = length(var.asg_name) <= 100
+    error_message = "Autoscaling Group name can not exceed 100 characters."
+  }
 }
 // --- Network Configuration ---
 variable "vpc_cidr" {

--- a/terraform/aws/qs-autoscale/variables.tf
+++ b/terraform/aws/qs-autoscale/variables.tf
@@ -23,11 +23,19 @@ variable "prefix" {
   type = string
   description = "(Optional) Instances name prefix"
   default = ""
+  validation {
+    condition     = length(var.prefix) <= 40
+    error_message = "Prefix can not exceed 40 characters."
+  }
 }
 variable "asg_name" {
   type = string
   description = "Autoscaling Group name"
-  default = "Check-Point-ASG-tf"
+  default = "Check-Point-Security-Gateway-AutoScaling-Group-tf"
+  validation {
+    condition     = length(var.asg_name) <= 100
+    error_message = "Autoscaling Group name can not exceed 100 characters."
+  }
 }
 // --- General Settings ---
 variable "vpc_id" {


### PR DESCRIPTION
VSECPC-6916 | Terraform | Added length limit to prefix and asg-name